### PR TITLE
Fix field data type

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -917,7 +917,6 @@ module.exports = (function() {
           // build a softdestroy query if setting is enabled
           if (softDelete === true) {
             query = sequel.update(table, options, { deletedAt: 'NOW()' });
-            console.log(query.query);
           } else {
             query = sequel.destroy(table, options);
           }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -787,7 +787,7 @@ module.exports = (function() {
           if (_.has(options, 'where')) {
             _.extend(options.where, { deletedAt: null });
           } else {
-            _.extend(options, { where: { deletedAt: null}});    
+            _.extend(options, { where: { deletedAt: null}});
           }
         }
 
@@ -829,7 +829,7 @@ module.exports = (function() {
         if (_.has(options, 'where')) {
           _.extend(options.where, { deletedAt: null });
         } else {
-          _.extend(options, { where: { deletedAt: null}});    
+          _.extend(options, { where: { deletedAt: null}});
         }
       }
 
@@ -1015,7 +1015,7 @@ module.exports = (function() {
 
         console.error('Troubleshooting tips:');
         console.error('');
-      
+
         // Used below to indicate whether the error is potentially related to config
         // (in which case we'll display a generic message explaining how to configure all the things)
         var isPotentiallyConfigRelated;
@@ -1052,7 +1052,7 @@ module.exports = (function() {
           );
           console.error('');
         }
-      
+
         // TODO: negotiate "Too many connections" error
         var tooManyConnections = true;
         if (tooManyConnections) {
@@ -1077,7 +1077,7 @@ module.exports = (function() {
           );
           console.error('');
         }
-        
+
         // TODO: negotiate the error code here to make the heuristic more helpful
         var isSSLRelated = !usingLocalhost;
         if (isSSLRelated) {
@@ -1086,7 +1086,7 @@ module.exports = (function() {
           );
           console.error('');
         }
-        
+
 
         console.error('');
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -207,7 +207,7 @@ module.exports = (function() {
         var connectionObject = connections[connectionName];
         var collection = connectionObject.collections[table];
         if (connectionObject.config.softDelete && !definition.deletedAt) {
-          definition.deletedAt = { type: 'DATE' };
+          definition.deletedAt = { type: 'datetime' };
         }
 
         // Escape Table Name


### PR DESCRIPTION
With Sails 10, `timestamp with time zone` fields are defined as `datetime`, not `DATE`.
